### PR TITLE
Adding initial page for developer guidelines concept

### DIFF
--- a/development-guidelines.md
+++ b/development-guidelines.md
@@ -1,0 +1,35 @@
+---
+layout: default
+---
+
+# Development Guidelines
+
+## Conventions and Patterns
+
+### Mediatr Components - Naming Conventions
+
+The project has adopted a CQRS pattern using the Mediatr library. We have discussed ([read discussion](https://github.com/HTBox/allReady/issues/1262)) the naming for these components and agreed that we will *not* suffix them with "Async".
+
+**Commands:**
+
+A command message should end with "Command" and descibe the action that is intended. e.g.
+
+- EditCampaignCommand
+- DeleteTaskCommand
+
+The handlers should match the command message name with the suffix of "Handler". e.g.
+
+- EditCampaignCommandHandler
+- DeleteTaskCommandHandler
+
+**Queries:**
+
+A query message should end with "Query" and describe the data it returns. e.g.
+
+- EventSummaryQuery
+- TaskDetailQuery
+
+The handlers should match the query message name with the suffix of "Handler". e.g.
+
+- EventSummaryQueryHandler
+- TaskDetailQueryHandler

--- a/development-guidelines.md
+++ b/development-guidelines.md
@@ -4,6 +4,8 @@ layout: default
 
 # Development Guidelines
 
+*These guidelines are based on the experience with the allReady project. These have been very helpful for us on this project, but may not be applicable to every project. We'll update these as we onboard other projects.*
+
 ## Conventions and Patterns
 
 ### Mediatr Components - Naming Conventions

--- a/index.html
+++ b/index.html
@@ -27,6 +27,7 @@ for work that you want to do to enhance our projects.
 <h2><a href="/getting-the-code.html">Getting the Code</a></h2>
 <h2><a href="/building-the-project.html">Building the Project</a></h2>
 <h2><a href="/doing-the-work.html">Doing the Work</a></h2>
+<h2><a href="/development-guidelines.html">Development Guidelines (Conventions and Patterns)</a></h2>
 <h2><a href="/submitting-a-pull-request.html">Submitting a Pull Request</a></h2>
 <h2><a href="/responding-to-reviews.html">Responding to Reviews</a></h2>
 <h1>FAQ</h1>


### PR DESCRIPTION
@BillWagner Adding initial concept of a development guidelines page covering recently discussed Mediatr. We will most likely need to refine as we determine the amount of content and detail we feel is right for the documentation.

cc @mgmccarthy
