### PR TITLE
#1198 renamed unittests to comply to naming convention

### DIFF
--- a/development-guidelines.md
+++ b/development-guidelines.md
@@ -35,3 +35,24 @@ The handlers should match the query message name with the suffix of "Handler". e
 
 - EventSummaryQueryHandler
 - TaskDetailQueryHandler
+
+### Unit Tests - Naming Conventions
+
+**Controller unit tests:**
+
+A controller unit test should be named as follows:
+
+- "Controllername" ControllerTests
+
+So, for instance: AdminControllerTests or GlobalControllerTests
+
+**Any other unit tests:**
+
+Any other unit tests should be named descriptevelit and end in "Should".
+
+Some examples:
+- DataReaderExtensionsShould
+- FormFileExtensionShould
+- ApplicationUserQueryShould
+
+


### PR DESCRIPTION
This is part of the allReady issue #1198
