### PR TITLE
fix for spelling typos 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # htbox.github.io
 This site provides the collection of our current policies on the Humanitarian Toolbox.
 In most cases, consider the guidance here as our current "default answer" to many
-important questios.
+important questions.
 
 If you are working on a project, and you have a different recommendation, we will 
 consider that request for a single project. IF it works well in that project,
-we will consdier making it the default answer on new projects. We'll also consider
+we will consider making it the default answer on new projects. We'll also consider
 adding that new policy to existing projects, in those cases where the benefits
 justify the work.
 

--- a/development-guidelines.md
+++ b/development-guidelines.md
@@ -48,7 +48,7 @@ So, for instance: AdminControllerTests or GlobalControllerTests
 
 **Any other unit tests:**
 
-Any other unit tests should be named descriptevelit and end in "Should".
+Any other unit tests should be named descriptively and end in "Should".
 
 Some examples:
 - DataReaderExtensionsShould

--- a/finding-a-task.md
+++ b/finding-a-task.md
@@ -14,11 +14,11 @@ We use Github issues to manage work. This could be proposed features, tasks unde
 
 Some projects have other upcoming milestones, based on customer needs, upcoming pilots, or upcoming releases.
 
-In addition, we label issues to provide some additional guidance. Within a milestone, we will use the 'P1', 'P2' and 'P3' labels to tag the priority of a task or feature. (P1 is the highest, P3 is the lowest.) In addition, we use the 'JumpIn' label (which is always green on our projects) to denote issues that would be suitable for someone not yet familiar with the project. The 'JumpIn' issues may not always represent simple fixes, but they do represent work that does not require a deep knowlege of the code base, or a deep knowledge of the business workflow for a project.
+In addition, we label issues to provide some additional guidance. Within a milestone, we will use the 'P1', 'P2' and 'P3' labels to tag the priority of a task or feature. (P1 is the highest, P3 is the lowest.) In addition, we use the 'jump-in' label (which is always green on our projects) to denote issues that would be suitable for someone not yet familiar with the project. The 'jump-in' issues may not always represent simple fixes, but they do represent work that does not require a deep knowlege of the code base, or a deep knowledge of the business workflow for a project.
 
 Other labels are project-specific and will be documented for that project.
 
-Tag yourself in a comment saying that you're working on an issue, and we'll start the converation. 
+Tag yourself in a comment saying that you're working on an issue, and we'll start the conversation. 
 
 You may notice that you can't assign yourself to work on an issue. That privilege is limited to the core team. Also, we can only assign issues to registered team members. If you enjoy working on our projects, we'll add you to the team, and we will assign tasks when you tag yourself.
 


### PR DESCRIPTION
also changed jump-in label to match how it shows in repos:   
'JumpIn' --> 'jump-in'