### PR TITLE
Simplify footer. Change About page to HTbox info

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -9,7 +9,7 @@
 title: Humanitarian Toolbox Developer Guide
 email: info@htbox.org
 description: > # this means to ignore newlines until "baseurl:"
-  Developer guidelines for working on HTbox projects.
+  Developer guidelines for working on HTbox projects
 baseurl: "" # the subpath of your site, e.g. /blog
 url: "http://htbox.org" # the base hostname & protocol for your site
 twitter_username: htbox

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -2,12 +2,12 @@
 
   <div class="wrapper">
 
-    <h2 class="footer-heading">{{ site.title }}</h2>
-
     <div class="footer-col-wrapper">
-      <div class="footer-col footer-col-1">
+
+      <div class="footer-col footer-col-4">
         <ul class="contact-list">
-          <li>{{ site.title }}</li>
+          <li class="footer-title">{{ site.title }}</li>
+          <li>{{ site.description }}</li>
           <li><a href="mailto:{{ site.email }}">{{ site.email }}</a></li>
         </ul>
       </div>
@@ -18,7 +18,7 @@
           <li>
             {% include icon-github.html username=site.github_username %}
           </li>
-          {% endif %}
+          {% endif %} 
 
           {% if site.twitter_username %}
           <li>
@@ -28,9 +28,6 @@
         </ul>
       </div>
 
-      <div class="footer-col footer-col-3">
-        <p>{{ site.description }}</p>
-      </div>
     </div>
 
   </div>

--- a/about.md
+++ b/about.md
@@ -4,12 +4,9 @@ title: About
 permalink: /about/
 ---
 
-This is the base Jekyll theme. You can find out more info about customizing your Jekyll theme, as well as basic Jekyll usage documentation at [jekyllrb.com](http://jekyllrb.com/)
+This developer guide is for Humanitarian Toolbox opensource projects on Github.  
 
-You can find the source code for the Jekyll new theme at:
-{% include icon-github.html username="jglovier" %} /
-[jekyll-new](https://github.com/jglovier/jekyll-new)
+More information about Humanitarian Toolbox can be found at [htbox.org](http://www.htbox.org/)
 
-You can find the source code for Jekyll at
-{% include icon-github.html username="jekyll" %} /
-[jekyll](https://github.com/jekyll/jekyll)
+See all HTBox github projects at {% include icon-github.html username=site.github_username %}
+

--- a/css/main.scss
+++ b/css/main.scss
@@ -9,6 +9,7 @@
 $base-font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
 $base-font-size:   16px;
 $base-font-weight: 400;
+$bold-font-weight: 700;
 $small-font-size:  $base-font-size * 0.875;
 $base-line-height: 1.5;
 
@@ -43,6 +44,14 @@ $on-laptop:        800px;
     }
 }
 
+.footer-title {
+    font-weight: $bold-font-weight;
+}
+
+.footer-col-4 {
+    width: -webkit-calc(55% - (#{$spacing-unit} / 2));
+    width:         calc(55% - (#{$spacing-unit} / 2));
+}
 
 
 // Import partials from `sass_dir` (defaults to `_sass`)


### PR DESCRIPTION
- Edited **About** page to show basic info about HTbox (instead of Jekyll theme info)
- Simplified **Footer**: Removed repeated site.title.   Also changed columns so doesn't cause line break in title and description.   Edit config.yaml to remove period at end of site.description for consistency.

**Footer Before**
![before2](https://cloud.githubusercontent.com/assets/15229372/26051792/93e36822-3963-11e7-858a-d74705329ae0.PNG)
**Footer After**
![after2](https://cloud.githubusercontent.com/assets/15229372/26070694/cd2f1e4a-39a5-11e7-874a-7a19ebf3a67e.PNG)

